### PR TITLE
fixed deprecations with numpy v1.20

### DIFF
--- a/cy_func.pyx.old
+++ b/cy_func.pyx.old
@@ -5,7 +5,7 @@ from libc.math cimport pow, exp, log
 cdef extern from "math.h" nogil:
     double HUGE_VAL
 
-DTYPE=np.float
+DTYPE=np.float64
 ctypedef np.float_t DTYPE_t
 
 from numpy import argsort

--- a/cy_kernel_smoothing.pyx
+++ b/cy_kernel_smoothing.pyx
@@ -7,7 +7,7 @@ from numpy import linalg
 cimport numpy as np
 from libc.math cimport exp, pow
 
-DTYPE = np.float
+DTYPE = np.float64
 ctypedef np.float_t DTYPE_t
 #ctypedef np.ndarray[DTYPE_t, ndim=2] ndarray2d_t
 #ctypedef np.ndarray[DTYPE_t, ndim=1] ndarray1d_t

--- a/pyqt_fit/cy_binning.pyx
+++ b/pyqt_fit/cy_binning.pyx
@@ -48,7 +48,7 @@ def fast_linbin(np.ndarray[DOUBLE] X, double a, double b, int M, np.ndarray[DOUB
     cdef:
         Py_ssize_t i, li_i
         int nobs = X.shape[0]
-        np.ndarray[DOUBLE] gcnts = np.zeros(M, np.float)
+        np.ndarray[DOUBLE] gcnts = np.zeros(M, np.float64)
         np.ndarray[DOUBLE] mesh
         double delta = (b - a) / M
         double inv_delta = 1 / delta

--- a/pyqt_fit/cy_local_linear.pyx
+++ b/pyqt_fit/cy_local_linear.pyx
@@ -3,7 +3,7 @@ import numpy as np
 cimport numpy as np
 from libc.math cimport exp
 
-DTYPE = np.float
+DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
 @cython.boundscheck(False)

--- a/pyqt_fit/sharedmem.py
+++ b/pyqt_fit/sharedmem.py
@@ -32,7 +32,7 @@ CTYPES_FLOAT_LIST = [ctypes.c_float,
                      ]
 
 CTYPES_TO_NUMPY = {ctypes.c_char: np.dtype(np.character),
-                   ctypes.c_wchar: np.dtype(np.unicode),
+                   ctypes.c_wchar: np.dtype(np.unicode_),
                    }
 
 

--- a/quad.pyx
+++ b/quad.pyx
@@ -3,7 +3,7 @@ import numpy as np
 from numpy import linalg
 cimport numpy as np
 
-DTYPE = np.float
+DTYPE = np.float64
 ctypedef np.float_t DTYPE_t
 
 def quadratic(np.ndarray[DTYPE_t, ndim=1] x, ps):


### PR DESCRIPTION
Removal of alias deprecations with NumPy v1.20 (see details here: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations%5Cn) and replacement with corresponding NumPy scalar type names